### PR TITLE
Updated Avro generator to fix class loader issue with Apache Velocity.

### DIFF
--- a/com.cohesionforce.apache.avro/META-INF/MANIFEST.MF
+++ b/com.cohesionforce.apache.avro/META-INF/MANIFEST.MF
@@ -4,12 +4,12 @@ Bundle-Name: Apache Avro
 Bundle-SymbolicName: com.cohesionforce.apache.avro
 Bundle-Version: 1.7.6
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-ClassPath: lib/jackson-core-asl-1.9.13.jar,
+Bundle-ClassPath: lib/avro-tools-1.7.6.jar,
+ lib/avro-1.7.6.jar,
+ lib/jackson-core-asl-1.9.13.jar,
  lib/jackson-mapper-asl-1.9.13.jar,
  lib/paranamer-2.3.jar,
- .,
- lib/avro-1.7.6.jar,
- lib/avro-tools-1.7.6.jar
+ .
 Import-Package: org.slf4j
 Export-Package: com.thoughtworks.paranamer,
  javax.servlet,

--- a/com.cohesionforce.avro.ui.tests/.classpath
+++ b/com.cohesionforce.avro.ui.tests/.classpath
@@ -1,16 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" output="target/test-classes" path="src">
-		<attributes>
-			<attribute name="test" value="true"/>
-		</attributes>
-	</classpathentry>
 	<classpathentry kind="src" output="target/test-classes" path="src-gen">
-		<attributes>
-			<attribute name="test" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="src" output="target/test-classes" path="xtend-gen">
 		<attributes>
 			<attribute name="test" value="true"/>
 		</attributes>

--- a/com.cohesionforce.avro.ui.tests/build.properties
+++ b/com.cohesionforce.avro.ui.tests/build.properties
@@ -1,6 +1,4 @@
-source.. = src/,\
-           src-gen/,\
-           xtend-gen/
+source.. = src-gen/
 bin.includes = .,\
                META-INF/
 bin.excludes = **/*.xtend

--- a/com.cohesionforce.avro.ui/META-INF/MANIFEST.MF
+++ b/com.cohesionforce.avro.ui/META-INF/MANIFEST.MF
@@ -6,7 +6,8 @@ Bundle-Vendor: My Company
 Bundle-Version: 1.0.0.qualifier
 Bundle-SymbolicName: com.cohesionforce.avro.ui; singleton:=true
 Bundle-ActivationPolicy: lazy
-Require-Bundle: com.cohesionforce.avro,
+Require-Bundle: com.cohesionforce.apache.avro;bundle-version="1.7.6",
+ com.cohesionforce.avro,
  com.cohesionforce.avro.ide,
  org.eclipse.xtext.ui,
  org.eclipse.xtext.ui.shared,
@@ -22,10 +23,8 @@ Require-Bundle: com.cohesionforce.avro,
  org.eclipse.e4.ui.services;bundle-version="1.3.600",
  org.eclipse.emf.codegen;bundle-version="2.19.0",
  org.eclipse.emf.codegen.ecore;bundle-version="2.19.0",
- org.eclipse.e4.core.contexts;bundle-version="1.8.200",
- com.cohesionforce.apache.avro;bundle-version="1.7.6"
-Import-Package: org.apache.avro,
- org.apache.log4j,
+ org.eclipse.e4.core.contexts;bundle-version="1.8.200"
+Import-Package: org.apache.log4j,
  org.slf4j
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: com.cohesionforce.avro.ui.internal,

--- a/com.cohesionforce.avro.ui/src/com/cohesionforce/avro/gen/handler/GenerateFromGenModelHandler.java
+++ b/com.cohesionforce.avro.ui/src/com/cohesionforce/avro/gen/handler/GenerateFromGenModelHandler.java
@@ -123,6 +123,16 @@ public class GenerateFromGenModelHandler {
 		}
 
 		IResource sourceResource = workspaceRoot.findMember(genModel.getModelDirectory());
+		if(sourceResource == null)
+		{
+			System.err.println("Could not find model directory from genModel");
+			return;
+		}
+		
+		if(sourceResource.getLocationURI() == null)
+		{
+			System.err.println("Could not find location of genModel resource");
+		}
 		File locationFile = new File(sourceResource.getLocationURI());
 		IPath schemaDirPath = ifile.getFullPath().append("schema");
 		IResource schemaDirResource = workspaceRoot.findMember(schemaDirPath);

--- a/com.cohesionforce.avro.ui/xtend-gen/com/cohesionforce/avro/ui/AvroSchemaUiModule.java
+++ b/com.cohesionforce.avro.ui/xtend-gen/com/cohesionforce/avro/ui/AvroSchemaUiModule.java
@@ -13,7 +13,7 @@ import org.eclipse.xtend.lib.annotations.FinalFieldsConstructor;
 @FinalFieldsConstructor
 @SuppressWarnings("all")
 public class AvroSchemaUiModule extends AbstractAvroSchemaUiModule {
-  public AvroSchemaUiModule(final AbstractUIPlugin arg0) {
-    super(arg0);
+  public AvroSchemaUiModule(final AbstractUIPlugin plugin) {
+    super(plugin);
   }
 }

--- a/com.cohesionforce.avro/src/com/cohesionforce/avro/gen/AvroSchemaGenerator.xtend
+++ b/com.cohesionforce.avro/src/com/cohesionforce/avro/gen/AvroSchemaGenerator.xtend
@@ -65,12 +65,35 @@ class AvroSchemaGenerator {
 	}
 
 	def void generateAvroSchema(GenModel genModel, IFileSystemAccess fileAccess) {
+		if(genModel === null)
+		{
+			System.err.println('Cannot generate from a null model');
+			return;
+		}
+		if(fileAccess === null)
+		{
+			System.err.println('Cannot generate null fileAccess');
+			return;
+		}
 		for (GenPackage genPackage : genModel.getGenPackages()) {
-			Utility.setBasePackage(genPackage.basePackage);
+			var basePackage = genPackage.basePackage;
+			if(basePackage === null)
+			{
+				basePackage = '';
+				Utility.setBasePackage('');
+			}
+			else
+			{
+				Utility.setBasePackage(basePackage);
+			}
+			if(genPackage.prefix === null)
+			{
+				System.err.println('Cannot generate null prefix');
+				return;
+			}
 			Utility.setFactory(genPackage.getPrefix() + "Factory");
 			Utility.setPackage(genPackage.getPrefix() + "Package");
-
-			generateAvroSchema(genPackage.getEcorePackage(), genPackage.basePackage, fileAccess);
+			generateAvroSchema(genPackage.getEcorePackage(), basePackage, fileAccess);
 		}
 	}
 

--- a/com.cohesionforce.avro/xtend-gen/com/cohesionforce/avro/gen/AvroSchemaGenerator.java
+++ b/com.cohesionforce.avro/xtend-gen/com/cohesionforce/avro/gen/AvroSchemaGenerator.java
@@ -73,17 +73,37 @@ public class AvroSchemaGenerator {
   }
   
   public void generateAvroSchema(final GenModel genModel, final IFileSystemAccess fileAccess) {
+    if ((genModel == null)) {
+      System.err.println("Cannot generate from a null model");
+      return;
+    }
+    if ((fileAccess == null)) {
+      System.err.println("Cannot generate null fileAccess");
+      return;
+    }
     EList<GenPackage> _genPackages = genModel.getGenPackages();
     for (final GenPackage genPackage : _genPackages) {
       {
-        Utility.setBasePackage(genPackage.getBasePackage());
+        String basePackage = genPackage.getBasePackage();
+        if ((basePackage == null)) {
+          basePackage = "";
+          Utility.setBasePackage("");
+        } else {
+          Utility.setBasePackage(basePackage);
+        }
         String _prefix = genPackage.getPrefix();
-        String _plus = (_prefix + "Factory");
-        Utility.setFactory(_plus);
+        boolean _tripleEquals = (_prefix == null);
+        if (_tripleEquals) {
+          System.err.println("Cannot generate null prefix");
+          return;
+        }
         String _prefix_1 = genPackage.getPrefix();
-        String _plus_1 = (_prefix_1 + "Package");
+        String _plus = (_prefix_1 + "Factory");
+        Utility.setFactory(_plus);
+        String _prefix_2 = genPackage.getPrefix();
+        String _plus_1 = (_prefix_2 + "Package");
         Utility.setPackage(_plus_1);
-        this.generateAvroSchema(genPackage.getEcorePackage(), genPackage.getBasePackage(), fileAccess);
+        this.generateAvroSchema(genPackage.getEcorePackage(), basePackage, fileAccess);
       }
     }
   }


### PR DESCRIPTION
The Avro compiler was throwing exceptions for something about an Apache Velocity resource manager not implementing the correct interface. It turned out to be a class loader issue where Velocity is not set up to work with an OSGi class loading scheme.